### PR TITLE
Added awaiting sleeps

### DIFF
--- a/TranAx Extension/Resources/content.js
+++ b/TranAx Extension/Resources/content.js
@@ -35,15 +35,18 @@ async function gatherData(toDate) {
            
             // go back
             //document.querySelector("[link-identifier='Purchase history']").click();
+            await sleep(2000);
             window.history.back();
+            await sleep(2000);
             await waitForElement("[data-testid*='orderGroup']");
             console.log(`Order: ${orders}`);
         }
 
         // next page
-        let url = location.href;
+        const originalOrderText = document.querySelector("[data-testid='order-0']").textContent;
         document.querySelector("button[data-automation-id='next-pages-button']").click();
-        await waitForLocationChange(url);
+        await sleep(2000);
+        await waitForElementContentChange("[data-testid='order-0']", 20000, el => el.textContent, originalOrderText);
         await waitForElement("button[data-automation-id='next-pages-button']");
 
     } while(orders.at(-1).orderDate > toDate)

--- a/TranAx Extension/Resources/manifest.json
+++ b/TranAx Extension/Resources/manifest.json
@@ -4,7 +4,7 @@
 
     "name": "__MSG_extension_name__",
     "description": "__MSG_extension_description__",
-    "version": "1.0.2",
+    "version": "1.0.4",
 
     "icons": {
         "48": "images/icon-48.png",

--- a/TranAx Extension/Resources/wait.js
+++ b/TranAx Extension/Resources/wait.js
@@ -64,7 +64,91 @@ function waitForLocationChange(oldHref, timeout = 10000, interval = 100) {
   });
 }
 
+function waitForElementContentChange(selector, timeout = 20000, getValue = el => el.textContent, originalValue, settleTime = 0) {
+  return new Promise((resolve, reject) => {
+    let observer = null;
+    let timer = null;
+    let settleTimer = null;
+
+    const cleanup = () => {
+      if (observer) {
+        observer.disconnect();
+        observer = null;
+      }
+
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+
+      if (settleTimer) {
+        clearTimeout(settleTimer);
+        settleTimer = null;
+      }
+    };
+
+    const finish = (error, el) => {
+      cleanup();
+      if (error) reject(error);
+      else resolve(el);
+    };
+
+    const initialElement = document.querySelector(selector);
+    const initialValue = originalValue === undefined && initialElement
+      ? getValue(initialElement)
+      : originalValue;
+
+    const checkForChange = () => {
+      const el = document.querySelector(selector);
+      if (!el) return;
+
+      const currentValue = getValue(el);
+      const hasChanged = initialValue === undefined || currentValue !== initialValue;
+
+      if (!hasChanged) {
+        if (settleTimer) {
+          clearTimeout(settleTimer);
+          settleTimer = null;
+        }
+        return;
+      }
+
+      if (!settleTime) {
+        finish(null, el);
+        return;
+      }
+
+      if (settleTimer) clearTimeout(settleTimer);
+      settleTimer = setTimeout(() => {
+        const currentElement = document.querySelector(selector);
+        if (!currentElement) return;
+
+        const settledValue = getValue(currentElement);
+        const isStillChanged = initialValue === undefined || settledValue !== initialValue;
+        if (isStillChanged) {
+          finish(null, currentElement);
+        }
+      }, settleTime);
+    };
+
+    checkForChange();
+
+    observer = new MutationObserver(checkForChange);
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+      attributes: true
+    });
+
+    if (timeout) {
+      timer = setTimeout(() => {
+        finish(new Error(`Timeout waiting for content change in ${selector}`));
+      }, timeout);
+    }
+  });
+}
+
 function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
-

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,3 +1,28 @@
+#!/bin/zsh
+
+set -euo pipefail
+
+MANIFEST_PATH="TranAx Extension/Resources/manifest.json"
+
+current_version=$(perl -ne 'print "$1\n" if /"version"\s*:\s*"([^"]+)"/' "$MANIFEST_PATH")
+
+if [[ -z "$current_version" ]]; then
+  echo "Unable to read extension version from $MANIFEST_PATH" >&2
+  exit 1
+fi
+
+if [[ "$current_version" =~ ^(.*)-rc([0-9]{4})$ ]]; then
+  base_version="${match[1]}"
+  rc_number="${match[2]}"
+  next_version="${base_version}-rc$(printf '%04d' $((10#$rc_number + 1)))"
+else
+  next_version="${current_version}-rc0001"
+fi
+
+NEXT_VERSION="$next_version" perl -0pi -e 's/("version"\s*:\s*")[^"]+(")/$1 . $ENV{NEXT_VERSION} . $2/ge' "$MANIFEST_PATH"
+
+echo "Updated extension manifest version: $current_version -> $next_version"
+
 xcodebuild -project TranAx.xcodeproj \
            -scheme "TranAx" \
            -configuration Release \


### PR DESCRIPTION
The crux of the problem appears to be an issue with walmart doing long load periods even though the html content exists but can cycle rapidly, such that awaiting for specific elements is not entirely reliable.

These changes represent more of a workaround than a true solution. A more thorough approach in the future may be to observe not only for the element but also for specific content to ensure that it does not match what it previous matched.